### PR TITLE
#24 bucket should no longer use random provider

### DIFF
--- a/journal/week1.md
+++ b/journal/week1.md
@@ -50,3 +50,24 @@ This is the default file to load in terraform variables in blunk
 
 - TODO: document which terraform variables takes precedence.
 
+
+## Dealing With Configuration Drift
+
+## What happens if we lose our state file?
+
+If you lose your statefile, you most likley have to tear down all your cloud infrastructure manually.
+
+You can use terraform port but it won't for all cloud resources. You need check the terraform providers documentation for which resources support import.
+
+### Fix Missing Resources with Terraform Import
+
+`terraform import aws_s3_bucket.bucket bucket-name`
+
+[Terraform Import](https://developer.hashicorp.com/terraform/cli/import)
+[AWS S3 Bucket Import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#import)
+
+### Fix Manual Configuration
+
+If someone goes and delete or modifies cloud resource manually through ClickOps. 
+
+If we run Terraform plan is with attempt to put our infrastructure back into the expected state fixing Configuration Drift.

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,8 @@
-# https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string
-resource "random_string" "bucket_name" {
-  lower = true
-  upper = false
-  length = 32
-  special = false
-}
-
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
-resource "aws_s3_bucket" "example" {
+resource "aws_s3_bucket" "website_bucket" {
   # Bucket Naming Rules
   # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html?icmpid=docs_amazons3_console
-  bucket = random_string.bucket_name.result
+  bucket = var.bucket_name
   
   tags = {
     UserUuid = var.user_uuid

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
-output "random_bucket_name" {
-  value = random_string.bucket_name.result
+output "bucket_name" {
+  value = aws_s3_bucket.website_bucket.bucket
 }

--- a/providers.tf
+++ b/providers.tf
@@ -15,11 +15,7 @@ terraform {
 #     }
 #   }
   required_providers {
-    random = {
-      source = "hashicorp/random"
-      version = "3.5.1"
-    }
-    aws = {
+      aws = {
       source = "hashicorp/aws"
       version = "5.17.0"
     }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,1 +1,2 @@
 user_uuid="921ba9f8-e37f-40f0-8224-d188f9e9a767"
+bucket_name="tf-sync-with-andrew-bucket"

--- a/variables.tf
+++ b/variables.tf
@@ -6,3 +6,15 @@ variable "user_uuid" {
     error_message    = "The user_uuid value is not a valid UUID."
   }
 }
+variable "bucket_name" {
+  description = "The name of the AWS S3 bucket."
+  type        = string
+
+  validation {
+    condition     = (
+      length(var.bucket_name) >= 3 && length(var.bucket_name) <= 63 && 
+      can(regex("^([a-z0-9][a-z0-9-.]*[a-z0-9])$", var.bucket_name))
+    )
+    error_message = "Invalid bucket name. The bucket name must be between 3 and 63 characters. It must contain only letters, numbers, hyphens, or periods."
+  }
+}


### PR DESCRIPTION
bucket should no longer use random provider (major change) and checked configuration drift in terraform (in case someone does clickops by any chance and the bucket gets deleted)